### PR TITLE
Fix unreliable networking

### DIFF
--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -227,7 +227,7 @@ static u8 g_phy_addr = 0;
 
 #define NUM_RX_DESC PKTBUFSRX
 #define NUM_TX_DESC 1     /* Number of TX descriptors   */
-#define RX_BUFF_SZ  PKTSIZE_ALIGN
+#define RX_BUFF_SZ  1600 /* Hardware defaults to this */
 #define TX_BUFF_SZ  1514
 
 #define TOUT_LOOP   1000000
@@ -1161,7 +1161,7 @@ static int aspeednic_init(struct eth_device* dev, bd_t* bis)
   set_mac_control_register (dev);
 
   for (i = 0; i < NUM_RX_DESC; i++) {
-    rx_ring[i].status = cpu_to_le32(RXPKT_RDY + RX_BUFF_SZ);
+    rx_ring[i].status = cpu_to_le32(RXPKT_RDY);
     rx_ring[i].buf = (u32)(&rx_buffer[i]);
     rx_ring[i].reserved = 0;
   }
@@ -1181,6 +1181,7 @@ static int aspeednic_init(struct eth_device* dev, bd_t* bis)
 
   OUTL(dev, ((u32) &tx_ring), TXR_BADR_REG);
   OUTL(dev, ((u32) &rx_ring), RXR_BADR_REG);
+  OUTL(dev, RX_BUFF_SZ, RBSR_REG);
 
   START_MAC(dev);
 

--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -1334,6 +1334,12 @@ static int aspeednic_recv(struct eth_device* dev)
        * to the adapter.
        */
       rx_ring[rx_new].status &= cpu_to_le32(0x7FFFFFFF);
+
+      /*
+       * Ask the hardware for any other packets now that we have a known
+       * spare slot
+       */
+      OUTL(dev, POLL_DEMAND, RXPD_REG);
 //      rx_ring[rx_new].status = cpu_to_le32(RXPKT_RDY);
     }
 
@@ -1341,6 +1347,12 @@ static int aspeednic_recv(struct eth_device* dev)
      */
     rx_new = (rx_new + 1) % rxRingSize;
   }
+
+  /*
+   * Ask the hardware for more packets so that they'll be DMAed by the time
+   * we return to this loop
+   */
+  OUTL(dev, POLL_DEMAND, RXPD_REG);
 
   return length;
 }


### PR DESCRIPTION
The BMC has been failing to reliably TFTPboot large files, it turns out that busy networks could get the NIC into a state where it stops DMAing its received packets.
Patch 2/2 addresses this problem.
Patch 1/2 fixes an RX buffer size problem found along the way.