### PR TITLE
MAC needs to be stopped after starting

### DIFF
--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -580,6 +580,7 @@ int aspeednic_initialize(bd_t *bis)
 #if defined(CONFIG_MII) || defined(CONFIG_CMD_MII)
   miiphy_register(dev->name, faraday_mdio_read, faraday_mdio_write);
 #endif
+  dev->halt(dev);
 
   return 1;
 }
@@ -1359,6 +1360,7 @@ static int aspeednic_recv(struct eth_device* dev)
 
 static void aspeednic_halt(struct eth_device* dev)
 {
+  printf("Stopping Network\n");
   STOP_MAC(dev);
 }
 


### PR DESCRIPTION
We found that u-boot network was corrupting kernel memory.
This is because aspeednic_init is called at startup,
but if the u-boot network is not used, the network driver
is not cleaned up.  This fix is a temporary hack and just calls
the halt function after the init. This driver needs to be
reworked to not start network initially and use set_hwaddr hook
to setup MAC address.  

Signed-off-by: Norman James <nkskjames@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openbmc/u-boot/3)
<!-- Reviewable:end -->
