### PR TITLE
Only call aspeednic_init when preparing to use network

### DIFF
--- a/README
+++ b/README
@@ -4764,7 +4764,8 @@ o If both the SROM and the environment contain a MAC address, and the
   warning is printed.
 
 o If neither SROM nor the environment contain a MAC address, an error
-  is raised.
+  is raised. If CONFIG_RANDOM_MACADDR is defined, then in this case
+  a random, locally-assigned MAC is used.
 
 If Ethernet drivers implement the 'write_hwaddr' function, valid MAC addresses
 will be programmed into hardware as part of the initialization process.	 This

--- a/doc/README.enetaddr
+++ b/doc/README.enetaddr
@@ -37,6 +37,8 @@ Correct flow of setting up the MAC address (summarized):
    environment variable will be used unchanged.
    If the environment variable is not set, it will be initialized from
    eth_device->enetaddr, and a warning will be printed.
+   If both are invalid and CONFIG_RANDOM_MACADDR is defined, a random,
+   locally-assigned MAC is written to eth_device->enetaddr.
 4. Program the address into hardware if the following conditions are met:
 	a) The relevant driver has a 'write_addr' function
 	b) The user hasn't set an 'ethmacskip' environment variable

--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -574,8 +574,6 @@ int aspeednic_initialize(bd_t *bis)
     udelay(10 * 1000);
   }
 
-  dev->init(dev, bis);
-
   eth_register(dev);
 
 #if defined(CONFIG_MII) || defined(CONFIG_CMD_MII)

--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -411,7 +411,7 @@ static int   aspeednic_init(struct eth_device* dev, bd_t* bis);
 static int   aspeednic_send(struct eth_device* dev, volatile void *packet, int length);
 static int   aspeednic_recv(struct eth_device* dev);
 static void  aspeednic_halt(struct eth_device* dev);
-static void  set_mac_address (struct eth_device* dev, bd_t* bis);
+static int   aspeednic_write_hwaddr(struct eth_device* dev);
 static void  phy_write_register (struct eth_device* dev, u8 PHY_Register, u8 PHY_Address, u16 PHY_Data);
 static u16   phy_read_register (struct eth_device* dev, u8 PHY_Register, u8 PHY_Address);
 #if defined(CONFIG_MII) || defined(CONFIG_CMD_MII)
@@ -564,6 +564,7 @@ int aspeednic_initialize(bd_t *bis)
   dev->halt   = aspeednic_halt;
   dev->send   = aspeednic_send;
   dev->recv   = aspeednic_recv;
+  dev->write_hwaddr = aspeednic_write_hwaddr;
 
   /* Ensure we're not sleeping. */
   if (CONFIG_ASPEED_MAC_PHY_SETTING >= 1) {
@@ -1157,7 +1158,7 @@ static int aspeednic_init(struct eth_device* dev, bd_t* bis)
 
   aspeednic_probe_phy(dev);
 
-  set_mac_address (dev, bis);
+  aspeednic_write_hwaddr(dev);
   set_mac_control_register (dev);
 
   for (i = 0; i < NUM_RX_DESC; i++) {
@@ -1362,7 +1363,7 @@ static void aspeednic_halt(struct eth_device* dev)
   STOP_MAC(dev);
 }
 
-static void set_mac_address (struct eth_device* dev, bd_t* bis)
+static int aspeednic_write_hwaddr(struct eth_device* dev)
 {
   if (!eth_getenv_enetaddr_by_index("eth", 0, dev->enetaddr)) {
     eth_random_enetaddr(dev->enetaddr);
@@ -1374,6 +1375,8 @@ static void set_mac_address (struct eth_device* dev, bd_t* bis)
   if (CONFIG_ASPEED_MAC_PHY_SETTING >= 1) {
     memcpy(NCSI_Request.SA, dev->enetaddr, 6);
   }
+
+  return 0;
 }
 
 static u16 phy_read_register (struct eth_device* dev, u8 PHY_Register, u8 PHY_Address)

--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -1363,10 +1363,6 @@ static void aspeednic_halt(struct eth_device* dev)
 
 static int aspeednic_write_hwaddr(struct eth_device* dev)
 {
-  if (!eth_getenv_enetaddr_by_index("eth", 0, dev->enetaddr)) {
-    eth_random_enetaddr(dev->enetaddr);
-  }
-
   OUTL(dev, ((dev->enetaddr[2] << 24) | (dev->enetaddr[3] << 16)
              | (dev->enetaddr[4] << 8) | dev->enetaddr[5]), MAC_LADR_REG);
   OUTL(dev, ((dev->enetaddr[0] << 8) | dev->enetaddr[1]), MAC_MADR_REG);

--- a/drivers/net/aspeednic.c
+++ b/drivers/net/aspeednic.c
@@ -560,10 +560,10 @@ int aspeednic_initialize(bd_t *bis)
   *(volatile u_long *)(SCU_BASE + SCU_SCRATCH_REGISTER) = cpu_to_le32((SCURegister & ~(0x3000)) | (CONFIG_MAC2_PHY_SETTING << 12));
 
 
-  dev->init   = aspeednic_init;
-  dev->halt   = aspeednic_halt;
-  dev->send   = aspeednic_send;
-  dev->recv   = aspeednic_recv;
+  dev->init = aspeednic_init;
+  dev->halt = aspeednic_halt;
+  dev->send = aspeednic_send;
+  dev->recv = aspeednic_recv;
   dev->write_hwaddr = aspeednic_write_hwaddr;
 
   /* Ensure we're not sleeping. */
@@ -1267,9 +1267,9 @@ static int aspeednic_send(struct eth_device* dev, volatile void *packet, int len
 //            memset ((void *)cpu_to_le32((u32) (packet + length)), 0, 60 - length);
     length = 60;
   }
-  tx_ring[tx_new].buf    = cpu_to_le32(((u32) packet));
-  tx_ring[tx_new].status   &= (~(0x3FFF));
-  tx_ring[tx_new].status   |= cpu_to_le32(LTS | FTS | length);
+  tx_ring[tx_new].buf = cpu_to_le32(((u32) packet));
+  tx_ring[tx_new].status &= (~(0x3FFF));
+  tx_ring[tx_new].status |= cpu_to_le32(LTS | FTS | length);
   tx_ring[tx_new].status |= cpu_to_le32(TXDMA_OWN);
 
   OUTL(dev, POLL_DEMAND, TXPD_REG);
@@ -1297,7 +1297,7 @@ static int aspeednic_send(struct eth_device* dev, volatile void *packet, int len
 static int aspeednic_recv(struct eth_device* dev)
 {
   s32   status;
-  int   length    = 0;
+  int   length = 0;
 
   for ( ; ; )
   {

--- a/net/eth.c
+++ b/net/eth.c
@@ -109,6 +109,7 @@ static int __def_eth_init(bd_t *bis)
 {
 	return -1;
 }
+
 int cpu_eth_init(bd_t *bis) __attribute__((weak, alias("__def_eth_init")));
 int board_eth_init(bd_t *bis) __attribute__((weak, alias("__def_eth_init")));
 
@@ -214,7 +215,17 @@ int eth_write_hwaddr(struct eth_device *dev, const char *base_name,
 		eth_setenv_enetaddr_by_index(base_name, eth_number,
 					     dev->enetaddr);
 		printf("\nWarning: %s using MAC address from net device\n",
-			dev->name);
+		       dev->name);
+	} else if (is_zero_ether_addr(dev->enetaddr)) {
+#ifdef CONFIG_RANDOM_MACADDR
+		eth_random_enetaddr(dev->enetaddr);
+		printf("\nWarning: %s (eth%d) using random MAC address - %pM\n",
+		       dev->name, eth_number, dev->enetaddr);
+#else
+		printf("\nError: %s address not set.\n",
+		       dev->name);
+		return -EINVAL;
+#endif
 	}
 
 	if (dev->write_hwaddr &&


### PR DESCRIPTION
The aspeednic driver was calling init from its initialization function and
calling halt later.  This left the DMA engine running and writing to
memory when Ethernet traffic arrived when control was handed off
to the operating system.

Remove this call to init and rely on the framework to call
write_hwaddr with the assigned MAC address.

In addition upstream discourages setting the random address in
drivers.  Later upstream created a config for this behavior and I
back-ported that patch.

In my testing, the random mac address is about 90% 1 value after a
u-boot reset command but after a kernel reboot it does not repeat.

The code uses rand with timer as the seed source; the network stack
then uses the mac as the seed for random delays.  We may prefer
to only configure u-boot setting a random mac only after a better
source of entropy, letting the kernel use its sources to set it when
we do not net-boot.

milton

<!-- Reviewable:start -->
---

v2: update README and README.ethaddr with backported CONFIG var name.

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openbmc/u-boot/4)
<!-- Reviewable:end -->
