### PR TITLE
aspeed/ast-g5: Simplify default bootargs

### DIFF
--- a/include/configs/ast-g5.h
+++ b/include/configs/ast-g5.h
@@ -139,7 +139,7 @@
 
 #define CONFIG_SYS_LOAD_ADDR		0x83000000	/* default load address */
 
-#define CONFIG_BOOTARGS		"console=ttyS0,115200n8 ramdisk_size=16384 root=/dev/ram rw init=/linuxrc mem=80M"
+#define CONFIG_BOOTARGS		"console=ttyS4,115200 earlyprintk"
 
 /* ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
New arguments set default console for DEBUG_UART (ttyS4) on the EVB and allow the kernel to choose init path, root/overlay, and memory size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/u-boot/7)
<!-- Reviewable:end -->
